### PR TITLE
Fix footer links overflow on mobile

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -8,7 +8,7 @@ export default function Footer() {
       <div className="max-w-main flex-1">
         <div className="flex h-full w-full items-end justify-between border-t border-solid border-neutral-500/10 pt-8 dark:border-neutral-900">
           <div className="flex-1">
-            <ul className="flex gap-4 pb-6">
+            <ul className="flex flex-wrap gap-4 pb-6">
             <li>
               <Link href="/" className="link-fade">
                 Home


### PR DESCRIPTION
## Problem

Footer links overflow horizontally on mobile screens, causing horizontal scroll and misalignment.

## Solution

Add `flex-wrap` to the footer links container so they wrap to multiple lines on narrow viewports.

```diff
- <ul className="flex gap-4 pb-6">
+ <ul className="flex flex-wrap gap-4 pb-6">
```

## Before / After (375px mobile)

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/soVN3ob.png) | ![After](https://i.imgur.com/EQCNAUq.png) |

**Before:** All links on single row, "Colophon" at edge  
**After:** Links wrap, "Colophon" moves to second row
