### PR TITLE
Truncate book titles at colon to hide subtitles

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,15 @@ import { getRecentlyPlayed } from "../lib/spotify";
 import { getAllPosts } from "../lib/sanity";
 import Badge from "../components/Badge";
 
+// Truncate book titles at colon (treat everything after as subtitle)
+function getDisplayTitle(title: string): string {
+  const colonIndex = title.indexOf(':');
+  if (colonIndex !== -1) {
+    return title.substring(0, colonIndex).trim();
+  }
+  return title;
+}
+
 export default function Home({
   recentPosts,
   lastCompleted,
@@ -109,7 +118,7 @@ export default function Home({
                     key={book.url}
                     className={`${index !== 0 ? "pt-2" : ""} truncate`}
                   >
-                    <LinkExternal href={book.url} imageUrl={book.imageUrl}>{book.title}</LinkExternal>
+                    <LinkExternal href={book.url} imageUrl={book.imageUrl}>{getDisplayTitle(book.title)}</LinkExternal>
                     <span className="truncate"> by {book.author}</span>
                     <Badge>READING</Badge>
                   </div>
@@ -117,7 +126,7 @@ export default function Home({
                 {lastCompleted && (
                   <div className="pt-2 opacity-30 dark:opacity-30 truncate">
                     <LinkExternal href={lastCompleted.url} imageUrl={lastCompleted.imageUrl}>
-                      {lastCompleted.title}
+                      {getDisplayTitle(lastCompleted.title)}
                     </LinkExternal>
                     <span className="truncate"> by {lastCompleted.author}</span>{" "}
                     <Badge>DONE</Badge>


### PR DESCRIPTION
Long titles like **The Fish That Ate the Whale: The Life and Times of America's Bar...** now display as just **The Fish That Ate the Whale** for cleaner presentation in the Reading section.

## Changes
- Added `getDisplayTitle()` helper function that truncates at the first colon
- Applied to both currently reading and completed books

## Before / After

| Before | After |
|--------|-------|
| ![Before](https://i.imgur.com/UD59eAh.png) | ![After](https://i.imgur.com/9mIlJnm.png) |

**Before:** Full title with subtitle overflows, no author visible  
**After:** Clean title, author name (Rich Cohen) now fits on the line