### PR TITLE
fix: remove double border on TextDiagram

### DIFF
--- a/components/TextDiagram/index.tsx
+++ b/components/TextDiagram/index.tsx
@@ -82,7 +82,7 @@ export function TextDiagram({ content, caption, captionPosition = 'bottom', minW
         
         <pre
           ref={preRef}
-          className="text-diagram-content font-mono text-sm leading-relaxed whitespace-pre p-6 sm:p-8 text-neutral-300 select-none"
+          className="text-diagram-content font-mono text-sm leading-relaxed whitespace-pre p-4 sm:p-5 text-neutral-300 select-none"
           style={{
             minWidth: minWidth ? `${minWidth}ch` : undefined,
           }}

--- a/lib/portableTextUtils.ts
+++ b/lib/portableTextUtils.ts
@@ -101,6 +101,15 @@ export function calculateReadingTime(content: PortableTextBlock[]): number {
       if (block._type === 'aside' && 'content' in block) {
         traverse((block as any).content)
       }
+      
+      // Handle textDiagram - only count caption words, not ASCII content
+      if (block._type === 'textDiagram' && 'caption' in block) {
+        const caption = (block as any).caption
+        if (caption && typeof caption === 'string') {
+          const captionWords = caption.trim().split(/\s+/).filter(word => word.trim().length > 0)
+          wordCount += captionWords.length
+        }
+      }
     }
   }
 
@@ -140,6 +149,18 @@ export function extractPlainText(content: PortableTextBlock[]): string[] {
       // Handle custom block types
       if (block._type === 'aside' && 'content' in block) {
         traverse((block as any).content)
+      }
+      
+      // Handle textDiagram - only include caption, skip the ASCII content
+      if (block._type === 'textDiagram' && 'caption' in block) {
+        const caption = (block as any).caption
+        if (caption && typeof caption === 'string') {
+          const captionWords = caption.trim().split(/\s+/).filter(word => {
+            const trimmed = word.trim()
+            return trimmed.length > 0 && trimmed.length <= 50
+          })
+          words.push(...captionWords)
+        }
       }
     }
   }

--- a/pages/colophon.tsx
+++ b/pages/colophon.tsx
@@ -31,8 +31,8 @@ export default function Colophon({ coffeeData }: { coffeeData: CoffeeData | null
             </h3>
           </dt>
           <dd className="list-content">
-          <p>
-              The majority of this website&apos;s code is forked from <a className="link" target="_blank" href="https://www.fabianschultz.com/">Fabian Schultz</a>, which is open source and available on <a className="link" target="_blank" href="https://github.com/fabe/site">Github</a>.
+            <p>
+              The majority of this website&apos;s code is forked from <a className="link" target="_blank" href="https://www.fabianschultz.com/">Fabian Schultz</a>, which is open source and available on <a className="link" target="_blank" href="https://github.com/fabe/site">Github</a>. Text diagram style inspired by <a className="link" target="_blank" href="https://drew.tech">Drew Bredvick</a>.
             </p>
           </dd>
         </dl>
@@ -45,18 +45,6 @@ export default function Colophon({ coffeeData }: { coffeeData: CoffeeData | null
           <dd className="list-content">
             <p>
               Built with <a className="link" target="_blank" href="https://nextjs.org">Next.js</a> and <a className="link" target="_blank" href="https://tailwindcss.com">Tailwind</a>, hosted on <a className="link" target="_blank" href="https://vercel.com">Vercel</a>. Vibe-coded with <a className="link" target="_blank" href="https://windsurf.com/">Windsurf</a> and <a className="link" target="_blank" href="https://ampcode.com">Amp</a>. The font face is <a className="link" target="_blank" href="https://rsms.me/inter/">Inter</a> by <a className="link" target="_blank" href="https://rsms.me">Rasmus Andersson</a>.
-            </p>
-          </dd>
-        </dl>
-        <dl className="list-container">
-          <dt className="list-title">
-            <h3 className="text-neutral-500 dark:text-silver-dark">
-              Inspiration
-            </h3>
-          </dt>
-          <dd className="list-content">
-            <p>
-              Text diagram style inspired by <a className="link" target="_blank" href="https://drew.tech">Drew Bredvick</a>.
             </p>
           </dd>
         </dl>

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -23,13 +23,12 @@ export default defineConfig({
     presentationTool({
       resolve: { locations, mainDocuments },
       previewUrl: {
-        initial: baseUrl,
+        origin: baseUrl,
         previewMode: {
           enable: '/api/draft-mode/enable',
           disable: '/api/draft-mode/disable',
         },
       },
-      allowOrigins: ['http://localhost:*', 'https://hem.so'],
     }),
     assist({
       assist: {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -472,6 +472,10 @@ a[href^="mailto:"] {
   /* Responsive font sizing */
   font-size: 0.75rem;
   line-height: 1.4;
+  /* Override prose styling that adds borders to pre elements */
+  border: none !important;
+  margin: 0 !important;
+  background: transparent !important;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
Fixes the double border issue where prose styling was adding an extra border to the pre element inside TextDiagram.

**Changes:**
- Override `prose-pre:border` styling on `.text-diagram-content`
- Reduce padding from p-6/p-8 to p-4/p-5 for tighter layout