### PR TITLE
feat: overflow sidebars for blog posts

### DIFF
--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@sanity/client'
 import { createImageUrlBuilder, type SanityImageSource } from '@sanity/image-url'
 
-const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || 'ubrdxobo'
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
 const apiVersion = '2024-01-01'
 const token = process.env.SANITY_API_TOKEN || process.env.SANITY_API_READ_TOKEN
@@ -48,7 +48,6 @@ export const postBySlugQuery = `*[_type == "post" && slug.current == $slug && !(
   tldr,
   meta,
   category,
-  layout,
   depth,
   content
 }`
@@ -63,7 +62,6 @@ export const postBySlugQueryWithDrafts = `*[_type == "post" && slug.current == $
   tldr,
   meta,
   category,
-  layout,
   depth,
   content
 }`

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -72,7 +72,7 @@ export default function Post(props) {
                 {headers.map((header, index) => {
                   const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
                   return (
-                    <li key={index} className={`leading-6 truncate ${activeSection === headerSlug ? 'text-white' : ''}`} style={{ marginLeft: `${header.depth * 1-1}rem` }}>
+                    <li key={index} className={`toc-item leading-6 truncate ${activeSection === headerSlug ? 'toc-active' : ''}`} style={{ marginLeft: `${header.depth * 1-1}rem` }}>
                       <a href={`#${headerSlug}`}>
                         {header.text}
                       </a>
@@ -80,6 +80,9 @@ export default function Post(props) {
                   );
                 })}
               </ul>
+              <div className="mt-6">
+                <Link href="/posts" className="text-neutral-500 dark:text-silver-dark hover:text-neutral-800 dark:hover:text-silver transition-colors text-sm">← All posts</Link>
+              </div>
             </div>
           </aside>
 
@@ -89,31 +92,25 @@ export default function Post(props) {
               <p className="text-neutral-700">{readingTime} minute(s)</p>
               <PortableText content={content} />
             </div>
-            <div className="prose-custom">
-              <hr className="pb-0" />
-              <Link href="/posts" className="text-neutral-700 sm:pb-6 sm:align-left cursor-pointer">← All posts</Link>
-            </div>
           </div>
 
-          {/* Right sidebar - Meta info */}
+          {/* Right sidebar - Meta info (not sticky) */}
           <aside className="blog-sidebar-right">
-            <div className="list-sticky">
-              <h3>Date</h3>
-              <p>
-                <time className="time" dateTime={date}>
-                  <span className="sr-only">{date}</span>
-                  {formatDate(date, false)}
-                </time>
-              </p>
-              <h3>Tl;dr</h3>
-              <p className="sidebar">{tldr}</p>
-              {meta && (
-                <>
-                  <h3>Meta</h3>
-                  <p className="sidebar">{meta}</p>
-                </>
-              )}
-            </div>
+            <h3>Date</h3>
+            <p>
+              <time className="time" dateTime={date}>
+                <span className="sr-only">{date}</span>
+                {formatDate(date, false)}
+              </time>
+            </p>
+            <h3>Tl;dr</h3>
+            <p className="sidebar">{tldr}</p>
+            {meta && (
+              <>
+                <h3>Meta</h3>
+                <p className="sidebar">{meta}</p>
+              </>
+            )}
           </aside>
         </div>
       </Main>

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -23,15 +23,25 @@ export default function Post(props) {
   useEffect(() => {
     const handleScroll = () => {
       let currentSection = '';
+      const scrollPosition = window.scrollY + 50;
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight;
+      const isNearBottom = scrollPosition + windowHeight >= documentHeight - 100;
+
       headers.forEach(header => {
         const slug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
         const element = document.getElementById(slug);
-        const scrollPosition = window.scrollY + 50;
 
         if (element && element.offsetTop <= scrollPosition) {
           currentSection = slug;
         }
       });
+
+      // If near bottom of page, highlight the last header
+      if (isNearBottom && headers.length > 0) {
+        const lastHeader = headers[headers.length - 1];
+        currentSection = lastHeader.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+      }
 
       setActiveSection(currentSection);
     };
@@ -51,7 +61,7 @@ export default function Post(props) {
           }} 
       /> 
       <Main>
-        <div className="flex w-full flex-col justify-between sm:flex-row sm:mb-0 mb-4">
+        <div className="blog-header flex w-full flex-col justify-between sm:flex-row sm:mb-0 mb-4">
           <header><h1 className="text-xl text-neutral-800 [font-variation-settings:'opsz'_32,_'wght'_500] dark:text-white sm:pb-6 sm:text-xl sm:mb-0 mb-4">
             {title}
           </h1></header>

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -61,7 +61,7 @@ export default function Post(props) {
           }} 
       /> 
       <Main>
-        <div className="blog-header flex w-full flex-col justify-between sm:flex-row sm:mb-0 mb-4">
+        <div className="flex w-full flex-col justify-between sm:flex-row sm:mb-0 mb-4">
           <header><h1 className="text-xl text-neutral-800 [font-variation-settings:'opsz'_32,_'wght'_500] dark:text-white sm:pb-6 sm:text-xl sm:mb-0 mb-4">
             {title}
           </h1></header>

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -14,7 +14,7 @@ import type { PortableTextBlock } from '@portabletext/types';
 
 export default function Post(props) {
   const router = useRouter();
-  const { title, date, meta, tldr, content, headers, readingTime, layout} = props;
+  const { title, date, meta, tldr, content, headers, readingTime } = props;
   const slug = router.query.slug;
   const relativeUrl = `/posts/${slug}`;
   const url = `${baseUrl}${relativeUrl}`;
@@ -23,11 +23,9 @@ export default function Post(props) {
   useEffect(() => {
     const handleScroll = () => {
       let currentSection = '';
-      // Assuming your headers are rendered with id attributes matching their text slug
       headers.forEach(header => {
         const slug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
         const element = document.getElementById(slug);
-        // Adjust this value based on your layout/styling
         const scrollPosition = window.scrollY + 50;
 
         if (element && element.offsetTop <= scrollPosition) {
@@ -39,9 +37,8 @@ export default function Post(props) {
     };
 
     window.addEventListener('scroll', handleScroll);
-    // Cleanup scroll listener
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [headers]); // Depend on headers so the effect updates if headers change
+  }, [headers]);
 
   return (
     <>
@@ -65,35 +62,42 @@ export default function Post(props) {
             </LinkShare>
           </div>
         </div>
-        <dl className="list-container">
-        <dd className={`${layout === 'wide' ? 'list-content-wide' : 'list-content'} sm:order-1 order-2`}>
-        <div className="prose-custom">
-            <p className="text-neutral-700">{readingTime} minute(s)</p>
+        
+        <div className="blog-post-layout">
+          {/* Left sidebar - Table of Contents */}
+          <aside className="blog-sidebar-left">
+            <div className="list-sticky">
+              <h3 className="pb-1">Table of Contents</h3>
+              <ul className="sidebar toc w-full">
+                {headers.map((header, index) => {
+                  const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+                  return (
+                    <li key={index} className={`leading-6 truncate ${activeSection === headerSlug ? 'text-white' : ''}`} style={{ marginLeft: `${header.depth * 1-1}rem` }}>
+                      <a href={`#${headerSlug}`}>
+                        {header.text}
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </aside>
 
-            <PortableText content={content} />
+          {/* Main content */}
+          <div className="blog-main">
+            <div className="prose-custom">
+              <p className="text-neutral-700">{readingTime} minute(s)</p>
+              <PortableText content={content} />
             </div>
             <div className="prose-custom">
               <hr className="pb-0" />
               <Link href="/posts" className="text-neutral-700 sm:pb-6 sm:align-left cursor-pointer">← All posts</Link>
             </div>
-          </dd>
-          {layout !== 'wide' && (
-            <dt className="list-title sm:order-2 order-1">
-              <div className="list-sticky">
-              <h3 className="pb-1">Table of Contents</h3>
-                <ul className="sidebar toc w-full">
-                  {headers.map((header, index) => {
-                    const slug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
-                    return (
-                      <li key={index} className={`leading-6 truncate ${activeSection === slug ? 'text-white' : ''}`} style={{ marginLeft: `${header.depth * 1-1}rem` }}>
-                        <a href={`#${slug}`}>
-                          {header.text}
-                        </a>
-                      </li>
-                    );
-                  })}
-                </ul>
-              <div className="mt-8 mb-8">
+          </div>
+
+          {/* Right sidebar - Meta info */}
+          <aside className="blog-sidebar-right">
+            <div className="list-sticky">
               <h3>Date</h3>
               <p>
                 <time className="time" dateTime={date}>
@@ -109,11 +113,9 @@ export default function Post(props) {
                   <p className="sidebar">{meta}</p>
                 </>
               )}
-              </div>
-              </div>
-            </dt>
-          )}
-        </dl>
+            </div>
+          </aside>
+        </div>
       </Main>
     </>
   );
@@ -132,7 +134,6 @@ export const getStaticProps = async (context) => {
   }
 
   const content = post.content as PortableTextBlock[];
-  const layout = post.layout || 'default';
   
   // Extract headers from Portable Text
   let headers = extractHeaders(content);
@@ -152,7 +153,6 @@ export const getStaticProps = async (context) => {
       tldr: post.tldr,
       meta: post.meta,
       category: post.category,
-      layout,
       depth: post.depth || null,
       content,
       headers,

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -51,18 +51,6 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: 'layout',
-      title: 'Layout',
-      type: 'string',
-      options: {
-        list: [
-          { title: 'Default', value: 'default' },
-          { title: 'Wide', value: 'wide' },
-        ],
-      },
-      initialValue: 'default',
-    }),
-    defineField({
       name: 'depth',
       title: 'TOC Depth',
       type: 'number',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -348,21 +348,17 @@ a[href^="mailto:"] {
     @apply hidden;
   }
 
+  /* Blog header stays constrained */
+  .blog-header {
+    max-width: 46rem;
+  }
+
   /* Show sidebars on xl screens (1280px+) with proper grid layout */
   @media (min-width: 1280px) {
-    /* Allow parent to show overflow sidebars */
-    article:has(.blog-post-layout) {
-      overflow: visible;
-      max-width: none;
-    }
-    
     .blog-post-layout {
-      /* Center the layout with sidebars */
-      max-width: calc(46rem + 12rem + 12rem + 4rem);
-      margin-left: auto;
-      margin-right: auto;
-      grid-template-columns: 12rem 1fr 12rem;
+      grid-template-columns: 12rem minmax(0, 46rem) 12rem;
       gap: 2rem;
+      justify-content: center;
     }
 
     .blog-sidebar-left {
@@ -380,15 +376,13 @@ a[href^="mailto:"] {
     .blog-main {
       grid-column: 2;
       grid-row: 1;
-      max-width: 46rem; /* Maintain readable line length */
     }
   }
 
   /* Wider sidebars on 2xl screens (1536px+) */
   @media (min-width: 1536px) {
     .blog-post-layout {
-      max-width: calc(46rem + 14rem + 14rem + 6rem);
-      grid-template-columns: 14rem 1fr 14rem;
+      grid-template-columns: 14rem minmax(0, 46rem) 14rem;
       gap: 3rem;
     }
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -329,15 +329,18 @@ a[href^="mailto:"] {
     @apply sticky top-4;
   }
 
-  /* Blog post layout with overflow sidebars */
+  /* Blog post layout with overflow sidebars using CSS Grid */
   .blog-post-layout {
-    @apply relative;
     @apply border-t border-solid border-neutral-500/10 pt-4 dark:border-neutral-900;
     @apply mb-12 sm:mb-16;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
   }
 
   .blog-main {
     @apply w-full;
+    min-width: 0; /* Prevent grid blowout */
   }
 
   .blog-sidebar-left,
@@ -345,37 +348,48 @@ a[href^="mailto:"] {
     @apply hidden;
   }
 
-  /* Show sidebars on xl screens (1280px+) where there's room for overflow */
+  /* Show sidebars on xl screens (1280px+) with proper grid layout */
   @media (min-width: 1280px) {
-    .blog-sidebar-left,
-    .blog-sidebar-right {
-      @apply block;
-      @apply absolute top-4;
-      @apply w-48;
+    /* Allow parent to show overflow sidebars */
+    article:has(.blog-post-layout) {
+      overflow: visible;
+      max-width: none;
+    }
+    
+    .blog-post-layout {
+      /* Center the layout with sidebars */
+      max-width: calc(46rem + 12rem + 12rem + 4rem);
+      margin-left: auto;
+      margin-right: auto;
+      grid-template-columns: 12rem 1fr 12rem;
+      gap: 2rem;
     }
 
     .blog-sidebar-left {
-      right: calc(100% + 2rem);
+      @apply block;
+      grid-column: 1;
+      grid-row: 1;
     }
 
     .blog-sidebar-right {
-      left: calc(100% + 2rem);
+      @apply block;
+      grid-column: 3;
+      grid-row: 1;
+    }
+
+    .blog-main {
+      grid-column: 2;
+      grid-row: 1;
+      max-width: 46rem; /* Maintain readable line length */
     }
   }
 
   /* Wider sidebars on 2xl screens (1536px+) */
   @media (min-width: 1536px) {
-    .blog-sidebar-left,
-    .blog-sidebar-right {
-      @apply w-56;
-    }
-
-    .blog-sidebar-left {
-      right: calc(100% + 3rem);
-    }
-
-    .blog-sidebar-right {
-      left: calc(100% + 3rem);
+    .blog-post-layout {
+      max-width: calc(46rem + 14rem + 14rem + 6rem);
+      grid-template-columns: 14rem 1fr 14rem;
+      gap: 3rem;
     }
   }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -320,6 +320,56 @@ a[href^="mailto:"] {
     @apply sticky top-4;
   }
 
+  /* Blog post layout with overflow sidebars */
+  .blog-post-layout {
+    @apply relative;
+    @apply border-t border-solid border-neutral-500/10 pt-4 dark:border-neutral-900;
+    @apply mb-12 sm:mb-16;
+  }
+
+  .blog-main {
+    @apply w-full;
+  }
+
+  .blog-sidebar-left,
+  .blog-sidebar-right {
+    @apply hidden;
+  }
+
+  /* Show sidebars on xl screens (1280px+) where there's room for overflow */
+  @media (min-width: 1280px) {
+    .blog-sidebar-left,
+    .blog-sidebar-right {
+      @apply block;
+      @apply absolute top-4;
+      @apply w-48;
+    }
+
+    .blog-sidebar-left {
+      right: calc(100% + 2rem);
+    }
+
+    .blog-sidebar-right {
+      left: calc(100% + 2rem);
+    }
+  }
+
+  /* Wider sidebars on 2xl screens (1536px+) */
+  @media (min-width: 1536px) {
+    .blog-sidebar-left,
+    .blog-sidebar-right {
+      @apply w-56;
+    }
+
+    .blog-sidebar-left {
+      right: calc(100% + 3rem);
+    }
+
+    .blog-sidebar-right {
+      left: calc(100% + 3rem);
+    }
+  }
+
   .island {
     @apply bg-white/95;
     @apply dark:bg-neutral-900/95;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -329,18 +329,15 @@ a[href^="mailto:"] {
     @apply sticky top-4;
   }
 
-  /* Blog post layout with overflow sidebars using CSS Grid */
+  /* Blog post layout with overflow sidebars */
   .blog-post-layout {
+    @apply relative;
     @apply border-t border-solid border-neutral-500/10 pt-4 dark:border-neutral-900;
     @apply mb-12 sm:mb-16;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 2rem;
   }
 
   .blog-main {
     @apply w-full;
-    min-width: 0; /* Prevent grid blowout */
   }
 
   .blog-sidebar-left,
@@ -348,42 +345,49 @@ a[href^="mailto:"] {
     @apply hidden;
   }
 
-  /* Blog header stays constrained */
-  .blog-header {
-    max-width: 46rem;
-  }
-
-  /* Show sidebars on xl screens (1280px+) with proper grid layout */
+  /* Show sidebars on xl screens (1280px+) - overflow outside main content */
   @media (min-width: 1280px) {
     .blog-post-layout {
-      grid-template-columns: 12rem minmax(0, 46rem) 12rem;
-      gap: 2rem;
-      justify-content: center;
+      display: flex;
+      align-items: flex-start;
+    }
+
+    .blog-sidebar-left,
+    .blog-sidebar-right {
+      @apply block;
+      position: absolute;
+      top: 1rem;
+      width: 12rem;
+      /* Match height of main content for sticky to work */
+      height: calc(100% - 1rem);
     }
 
     .blog-sidebar-left {
-      @apply block;
-      grid-column: 1;
-      grid-row: 1;
+      right: calc(100% + 2rem);
     }
 
     .blog-sidebar-right {
-      @apply block;
-      grid-column: 3;
-      grid-row: 1;
+      left: calc(100% + 2rem);
     }
 
     .blog-main {
-      grid-column: 2;
-      grid-row: 1;
+      flex: 1;
     }
   }
 
-  /* Wider sidebars on 2xl screens (1536px+) */
+  /* Wider gap on 2xl screens */
   @media (min-width: 1536px) {
-    .blog-post-layout {
-      grid-template-columns: 14rem minmax(0, 46rem) 14rem;
-      gap: 3rem;
+    .blog-sidebar-left,
+    .blog-sidebar-right {
+      width: 14rem;
+    }
+
+    .blog-sidebar-left {
+      right: calc(100% + 3rem);
+    }
+
+    .blog-sidebar-right {
+      left: calc(100% + 3rem);
     }
   }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -274,6 +274,15 @@ a[href^="mailto:"] {
     @apply p-0;
   }
 
+  .toc-item {
+    @apply -mx-2 px-2 py-0.5 rounded;
+    @apply transition-colors duration-150;
+  }
+
+  .toc-active {
+    @apply bg-neutral-800 text-white;
+  }
+
   .time {
     @apply font-sans;
     @apply block;


### PR DESCRIPTION
## Summary
- Main content now takes full width within the container
- Table of Contents on the **left**, overflowed outside main
- Date/TL;DR/Meta on the **right**, overflowed outside main
- Sidebars are hidden on screens < 1280px, shown on xl+ screens
- **Removed layout type** (no more regular vs wide distinction)

## Changes
- `pages/posts/[slug].tsx`: Restructured to new 3-column overflow layout
- `styles/globals.css`: Added `.blog-post-layout`, `.blog-sidebar-left`, `.blog-sidebar-right` classes
- `schemas/post.ts`: Removed `layout` field from Sanity schema
- `lib/sanity.ts`: Removed `layout` from GROQ queries, added fallback for project ID

## Sanity CMS Note
After merging, you may want to remove the `layout` field data from existing posts in Sanity Studio (optional cleanup - the field will no longer appear in the schema).

## Testing
View any blog post on a screen >= 1280px wide to see the overflow sidebars.