### PR TITLE
feat: overflow sidebars for blog posts

### DIFF
--- a/components/TextDiagram/index.tsx
+++ b/components/TextDiagram/index.tsx
@@ -65,7 +65,7 @@ export function TextDiagram({ content, caption, captionPosition = 'bottom', minW
   }
 
   const captionElement = caption && (
-    <figcaption className="text-diagram-caption text-sm text-neutral-500 dark:text-silver-dark text-center py-2">
+    <figcaption className="text-diagram-caption text-sm text-neutral-500 dark:text-silver-dark text-left py-2">
       {caption}
     </figcaption>
   )

--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -48,7 +48,6 @@ export const postBySlugQuery = `*[_type == "post" && slug.current == $slug && !(
   tldr,
   meta,
   category,
-  layout,
   depth,
   content
 }`
@@ -63,7 +62,6 @@ export const postBySlugQueryWithDrafts = `*[_type == "post" && slug.current == $
   tldr,
   meta,
   category,
-  layout,
   depth,
   content
 }`

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -14,7 +14,7 @@ import type { PortableTextBlock } from '@portabletext/types';
 
 export default function Post(props) {
   const router = useRouter();
-  const { title, date, meta, tldr, content, headers, readingTime, layout} = props;
+  const { title, date, meta, tldr, content, headers, readingTime } = props;
   const slug = router.query.slug;
   const relativeUrl = `/posts/${slug}`;
   const url = `${baseUrl}${relativeUrl}`;
@@ -23,25 +23,30 @@ export default function Post(props) {
   useEffect(() => {
     const handleScroll = () => {
       let currentSection = '';
-      // Assuming your headers are rendered with id attributes matching their text slug
+      const scrollPosition = window.scrollY + 50;
+      const nearBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 300;
+
       headers.forEach(header => {
-        const slug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
-        const element = document.getElementById(slug);
-        // Adjust this value based on your layout/styling
-        const scrollPosition = window.scrollY + 50;
+        const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+        const element = document.getElementById(headerSlug);
 
         if (element && element.offsetTop <= scrollPosition) {
-          currentSection = slug;
+          currentSection = headerSlug;
         }
       });
+
+      // Activate last header when near bottom of page
+      if (nearBottom && headers.length > 0) {
+        const lastHeader = headers[headers.length - 1];
+        currentSection = lastHeader.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+      }
 
       setActiveSection(currentSection);
     };
 
     window.addEventListener('scroll', handleScroll);
-    // Cleanup scroll listener
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [headers]); // Depend on headers so the effect updates if headers change
+  }, [headers]);
 
   return (
     <>
@@ -65,55 +70,60 @@ export default function Post(props) {
             </LinkShare>
           </div>
         </div>
-        <dl className="list-container">
-        <dd className={`${layout === 'wide' ? 'list-content-wide' : 'list-content'} sm:order-1 order-2`}>
-        <div className="prose-custom">
-            <p className="text-neutral-700">{readingTime} minute(s)</p>
-
-            <PortableText content={content} />
-            </div>
-            <div className="prose-custom">
-              <hr className="pb-0" />
-              <Link href="/posts" className="text-neutral-700 sm:pb-6 sm:align-left cursor-pointer">← All posts</Link>
-            </div>
-          </dd>
-          {layout !== 'wide' && (
-            <dt className="list-title sm:order-2 order-1">
-              <div className="list-sticky">
+        <div className="post-layout">
+          {/* Left sidebar - TOC (sticky) */}
+          <aside className="post-sidebar-left">
+            <div className="post-sidebar-sticky">
               <h3 className="pb-1">Table of Contents</h3>
-                <ul className="sidebar toc w-full">
-                  {headers.map((header, index) => {
-                    const slug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
-                    return (
-                      <li key={index} className={`leading-6 truncate ${activeSection === slug ? 'text-white' : ''}`} style={{ marginLeft: `${header.depth * 1-1}rem` }}>
-                        <a href={`#${slug}`}>
-                          {header.text}
-                        </a>
-                      </li>
-                    );
-                  })}
-                </ul>
-              <div className="mt-8 mb-8">
-              <h3>Date</h3>
-              <p>
-                <time className="time" dateTime={date}>
-                  <span className="sr-only">{date}</span>
-                  {formatDate(date, false)}
-                </time>
-              </p>
-              <h3>Tl;dr</h3>
-              <p className="sidebar">{tldr}</p>
-              {meta && (
-                <>
-                  <h3>Meta</h3>
-                  <p className="sidebar">{meta}</p>
-                </>
-              )}
+              <ul className="sidebar toc w-full">
+                {headers.map((header, index) => {
+                  const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+                  return (
+                    <li 
+                      key={index} 
+                      className={`toc-item leading-6 truncate ${activeSection === headerSlug ? 'toc-active' : ''}`} 
+                      style={{ marginLeft: `${header.depth - 1}rem` }}
+                    >
+                      <a href={`#${headerSlug}`}>{header.text}</a>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="mt-6">
+                <Link href="/posts" className="text-neutral-500 dark:text-silver-dark hover:text-neutral-800 dark:hover:text-silver transition-colors text-sm">
+                  ← All posts
+                </Link>
               </div>
-              </div>
-            </dt>
-          )}
-        </dl>
+            </div>
+          </aside>
+
+          {/* Main content */}
+          <div className="post-content">
+            <p className="text-neutral-700 dark:text-silver-dark mb-6">{readingTime} minute(s)</p>
+            <div className="prose-custom">
+              <PortableText content={content} />
+            </div>
+          </div>
+
+          {/* Right sidebar - Meta (not sticky) */}
+          <aside className="post-sidebar-right">
+            <h3>Date</h3>
+            <p>
+              <time className="time" dateTime={date}>
+                <span className="sr-only">{date}</span>
+                {formatDate(date, false)}
+              </time>
+            </p>
+            <h3>Tl;dr</h3>
+            <p className="sidebar">{tldr}</p>
+            {meta && (
+              <>
+                <h3>Meta</h3>
+                <p className="sidebar">{meta}</p>
+              </>
+            )}
+          </aside>
+        </div>
       </Main>
     </>
   );
@@ -132,7 +142,6 @@ export const getStaticProps = async (context) => {
   }
 
   const content = post.content as PortableTextBlock[];
-  const layout = post.layout || 'default';
   
   // Extract headers from Portable Text
   let headers = extractHeaders(content);
@@ -152,7 +161,6 @@ export const getStaticProps = async (context) => {
       tldr: post.tldr,
       meta: post.meta,
       category: post.category,
-      layout,
       depth: post.depth || null,
       content,
       headers,

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -24,7 +24,6 @@ export default function Post(props) {
     const handleScroll = () => {
       let currentSection = '';
       const scrollPosition = window.scrollY + 50;
-      const nearBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 300;
 
       headers.forEach(header => {
         const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
@@ -35,10 +34,26 @@ export default function Post(props) {
         }
       });
 
-      // Activate last header when near bottom of page
-      if (nearBottom && headers.length > 0) {
+      // Activate last header when it's visible AND near page bottom
+      if (headers.length > 0) {
         const lastHeader = headers[headers.length - 1];
-        currentSection = lastHeader.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+        const lastHeaderSlug = lastHeader.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+        const lastElement = document.getElementById(lastHeaderSlug);
+        
+        if (lastElement) {
+          const lastHeaderTop = lastElement.offsetTop;
+          const viewportTop = window.scrollY;
+          const viewportBottom = window.scrollY + window.innerHeight;
+          const scrollRoomLeft = document.documentElement.scrollHeight - viewportBottom;
+          
+          // Is last header visible in viewport?
+          const lastHeaderVisible = lastHeaderTop >= viewportTop && lastHeaderTop <= viewportBottom;
+          
+          // Activate if visible AND less than 300px scroll room left
+          if (lastHeaderVisible && scrollRoomLeft < 300) {
+            currentSection = lastHeaderSlug;
+          }
+        }
       }
 
       setActiveSection(currentSection);

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -71,29 +71,27 @@ export default function Post(props) {
           </div>
         </div>
         <div className="post-layout">
-          {/* Left sidebar - TOC (sticky) */}
+          {/* Left sidebar - TOC (fixed on xl screens) */}
           <aside className="post-sidebar-left">
-            <div className="post-sidebar-sticky">
-              <h3 className="pb-1">Table of Contents</h3>
-              <ul className="sidebar toc w-full">
-                {headers.map((header, index) => {
-                  const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
-                  return (
-                    <li 
-                      key={index} 
-                      className={`toc-item leading-6 truncate ${activeSection === headerSlug ? 'toc-active' : ''}`} 
-                      style={{ marginLeft: `${header.depth - 1}rem` }}
-                    >
-                      <a href={`#${headerSlug}`}>{header.text}</a>
-                    </li>
-                  );
-                })}
-              </ul>
-              <div className="mt-6">
-                <Link href="/posts" className="text-neutral-500 dark:text-silver-dark hover:text-neutral-800 dark:hover:text-silver transition-colors text-sm">
-                  ← All posts
-                </Link>
-              </div>
+            <h3 className="pb-1">Table of Contents</h3>
+            <ul className="sidebar toc w-full">
+              {headers.map((header, index) => {
+                const headerSlug = header.text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]+/g, '');
+                return (
+                  <li 
+                    key={index} 
+                    className={`toc-item leading-6 truncate ${activeSection === headerSlug ? 'toc-active' : ''}`} 
+                    style={{ marginLeft: `${header.depth - 1}rem` }}
+                  >
+                    <a href={`#${headerSlug}`}>{header.text}</a>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="mt-6">
+              <Link href="/posts" className="text-neutral-500 dark:text-silver-dark hover:text-neutral-800 dark:hover:text-silver transition-colors text-sm">
+                ← All posts
+              </Link>
             </div>
           </aside>
 

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -51,18 +51,6 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: 'layout',
-      title: 'Layout',
-      type: 'string',
-      options: {
-        list: [
-          { title: 'Default', value: 'default' },
-          { title: 'Wide', value: 'wide' },
-        ],
-      },
-      initialValue: 'default',
-    }),
-    defineField({
       name: 'depth',
       title: 'TOC Depth',
       type: 'number',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -336,10 +336,6 @@ a[href^="mailto:"] {
     @apply hidden;
   }
 
-  .post-sidebar-sticky {
-    @apply sticky top-8;
-  }
-
   /* TOC item styles */
   .toc-item {
     @apply -mx-2 px-2 py-0.5 rounded;
@@ -352,33 +348,31 @@ a[href^="mailto:"] {
 
   /* Show sidebars on xl screens (1280px+) */
   @media (min-width: 1280px) {
-    .post-sidebar-left,
-    .post-sidebar-right {
-      @apply block absolute top-4;
-      width: 13rem;
-    }
-
     .post-sidebar-left {
-      right: calc(100% + 2rem);
+      @apply block fixed;
+      top: 8rem;
+      width: 13rem;
+      /* Position to the left of the main content area */
+      right: calc(50% + 23rem + 2rem);
     }
 
     .post-sidebar-right {
+      @apply block absolute;
+      top: 1rem;
+      width: 13rem;
       left: calc(100% + 2rem);
     }
   }
 
   /* Wider sidebars on 2xl screens (1536px+) */
   @media (min-width: 1536px) {
-    .post-sidebar-left,
+    .post-sidebar-left {
+      width: 14rem;
+      right: calc(50% + 23rem + 3rem);
+    }
+
     .post-sidebar-right {
       width: 14rem;
-    }
-
-    .post-sidebar-left {
-      right: calc(100% + 3rem);
-    }
-
-    .post-sidebar-right {
       left: calc(100% + 3rem);
     }
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -350,7 +350,7 @@ a[href^="mailto:"] {
   @media (min-width: 1280px) {
     .post-sidebar-left {
       @apply block fixed;
-      top: 8rem;
+      top: 12rem;
       width: 13rem;
       /* Position to the left of the main content area */
       right: calc(50% + 23rem + 2rem);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -320,6 +320,69 @@ a[href^="mailto:"] {
     @apply sticky top-4;
   }
 
+  /* Post layout with overflow sidebars */
+  .post-layout {
+    @apply relative;
+    @apply border-t border-solid border-neutral-500/10 pt-4 dark:border-neutral-900;
+    @apply mb-12 sm:mb-16;
+  }
+
+  .post-content {
+    @apply w-full;
+  }
+
+  .post-sidebar-left,
+  .post-sidebar-right {
+    @apply hidden;
+  }
+
+  .post-sidebar-sticky {
+    @apply sticky top-8;
+  }
+
+  /* TOC item styles */
+  .toc-item {
+    @apply -mx-2 px-2 py-0.5 rounded;
+    @apply transition-colors duration-150;
+  }
+
+  .toc-active {
+    @apply bg-neutral-800 text-white;
+  }
+
+  /* Show sidebars on xl screens (1280px+) */
+  @media (min-width: 1280px) {
+    .post-sidebar-left,
+    .post-sidebar-right {
+      @apply block absolute top-4;
+      width: 13rem;
+    }
+
+    .post-sidebar-left {
+      right: calc(100% + 2rem);
+    }
+
+    .post-sidebar-right {
+      left: calc(100% + 2rem);
+    }
+  }
+
+  /* Wider sidebars on 2xl screens (1536px+) */
+  @media (min-width: 1536px) {
+    .post-sidebar-left,
+    .post-sidebar-right {
+      width: 14rem;
+    }
+
+    .post-sidebar-left {
+      right: calc(100% + 3rem);
+    }
+
+    .post-sidebar-right {
+      left: calc(100% + 3rem);
+    }
+  }
+
   .island {
     @apply bg-white/95;
     @apply dark:bg-neutral-900/95;


### PR DESCRIPTION
## Summary
Restructured blog post layout with overflow sidebars.

### Layout
- **Left sidebar**: TOC + 'All posts' link (overflows left of main container)
- **Main content**: Stays within 46rem container
- **Right sidebar**: Date/TL;DR/Meta (overflows right of main container)
- **Header**: Title + buttons unchanged, stays within container

### Behavior
- Left sidebar is **sticky** on scroll
- Right sidebar is **not sticky**
- TOC active item has **dark grey background** highlight
- Last heading activates when within **300px of page bottom**

### Removed
- 'All posts' link from bottom of content (now in left sidebar)
- `layout` field from Sanity schema (no more regular vs wide)

### Files Changed
- `pages/posts/[slug].tsx` - New layout structure
- `styles/globals.css` - New CSS classes for post layout
- `schemas/post.ts` - Removed layout field
- `lib/sanity.ts` - Removed layout from GROQ queries