### PR TITLE
fix: aside grays all text + add Note block type

### DIFF
--- a/components/PortableText/index.tsx
+++ b/components/PortableText/index.tsx
@@ -8,12 +8,23 @@ interface PortableTextProps {
   content: PortableTextBlock[]
 }
 
-// Custom block renderer for Aside
+// Custom block renderer for Aside (grayed out text)
 const AsideBlock = ({ value }: { value: any }) => {
   if (!value.content) return null
   
   return (
-    <div className="prose-p:text-neutral-600">
+    <div className="aside-block text-neutral-500 dark:text-silver-dark [&_h1]:text-neutral-500 [&_h2]:text-neutral-500 [&_h3]:text-neutral-500 [&_h4]:text-neutral-500 [&_li]:text-neutral-500 dark:[&_h1]:text-silver-dark dark:[&_h2]:text-silver-dark dark:[&_h3]:text-silver-dark dark:[&_h4]:text-silver-dark dark:[&_li]:text-silver-dark">
+      <SanityPortableText value={value.content} components={defaultComponents} />
+    </div>
+  )
+}
+
+// Custom block renderer for Note (bordered box)
+const NoteBlock = ({ value }: { value: any }) => {
+  if (!value.content) return null
+  
+  return (
+    <div className="note my-6">
       <SanityPortableText value={value.content} components={defaultComponents} />
     </div>
   )
@@ -79,6 +90,7 @@ const TableBlock = ({ value }: { value: any }) => {
 const defaultComponents = {
   types: {
     aside: AsideBlock,
+    note: NoteBlock,
     table: TableBlock,
     textDiagram: TextDiagramBlock,
   },

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -153,6 +153,34 @@ export default defineType({
           },
         },
         {
+          type: 'object',
+          name: 'note',
+          title: 'Note',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{ type: 'block' }],
+            },
+          ],
+          preview: {
+            select: {
+              content: 'content',
+            },
+            prepare({ content }) {
+              const block = (content || []).find((item) => item._type === 'block')
+              return {
+                title: block
+                  ? block.children
+                      .filter((child) => child._type === 'span')
+                      .map((span) => span.text)
+                      .join('')
+                  : 'Note',
+              }
+            },
+          },
+        },
+        {
           type: 'table',
         },
         {


### PR DESCRIPTION
## Fixes

### Aside Component
- Now grays out **all** content inside (headers, lists, paragraphs)
- Previously only paragraphs were grayed, bullets/headers stayed white
- Uses Tailwind arbitrary variant selectors: `[&_h1]:text-neutral-500` etc.

### Note Block (New)
- Added new **Note** block type to Sanity CMS
- Renders as a bordered box (uses existing `.note` CSS class)
- Available in the content editor alongside Aside, Table, TextDiagram

## Files Changed
- `components/PortableText/index.tsx` - Fixed Aside styling, added NoteBlock
- `schemas/post.ts` - Added note block type to content array