### PR TITLE
Ensure full-height app shell on mobile and desktop

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,8 +2,19 @@
 @import "tailwindcss";
 
 html,
-body {
+body,
+#__next {
+  min-height: 100%;
   @apply bg-gray-50 dark:bg-zinc-950;
+}
+
+#__next {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+html,
+body {
   @apply text-neutral-800 dark:text-silver;
   @apply antialiased;
   @apply text-base;


### PR DESCRIPTION
## Summary
- Apply the global background to `#__next` alongside `html` and `body`
- Set the app root to use full viewport height with `100vh` and `100dvh`
- Keep the page filling the screen consistently across browsers and mobile address-bar behavior

## Notes
- This fixes cases where the root container did not stretch to the full viewport height.
- `100dvh` provides better behavior on mobile browsers with dynamic chrome.